### PR TITLE
chore: updates dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.9.0",
-    "git-rev-sync": "^1.6.0",
+    "git-rev-sync": "^3.0.1",
     "lodash.merge": "^4.4.0",
     "lodash.reduce": "^4.5.0",
     "lodash.set": "^4.3.0",


### PR DESCRIPTION
It updates the [git-rev-sync](https://www.npmjs.com/package/git-rev-sync) dependency in order to avoid the following error when creating the manifest:

`Error: ENOENT: no such file or directory, open '/PATH_TO_THE_FOLDER/.git/packed-refs'`