### PR TITLE
fix: fix scm generation when there is no git repository

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,17 @@ const gitRemote = require('remote-origin-url');
 
 module.exports = extra => {
     const { name, version } = pkg;
-    const scm = {
+    let scm = {};
+
+    if( fs.existsSync(path.join(process.cwd(), '.git'))){
+      scm = {
         remote: gitRemote.sync(),
         branch: gitCommit.branch(),
         commit: gitCommit.long()
+      }
     }
-    const timestamp = new Date().toISOString();
 
+    const timestamp = new Date().toISOString();
     const manifest = { name, version, scm, timestamp, ...extra };
     fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n', 'utf-8')
 }


### PR DESCRIPTION
Check if directory `.git` exists prior to `scm` information retrieval.